### PR TITLE
[FIX] Path traversal sanitizing request path

### DIFF
--- a/nodeserver.js
+++ b/nodeserver.js
@@ -32,7 +32,7 @@ function start(config) {
     var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp));
 
     // Sanitize *nowTemp* variable to avoid *Path Traversal* attacks
-  var nowTemp = path.normalize(nowTemp).replace(/^(\.\.(\/|\\|$))+/, '');
+    var nowTemp = path.normalize(nowTemp).replace(/^(\.\.(\/|\\|$))+/, '');
 
     var httpHead = header(nowTemp);
     conf.app = conf.getApp(host.backend);

--- a/nodeserver.js
+++ b/nodeserver.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var header = require('./tool/httpHeader').contentType;
 var route = require('./router').response;
 var conf = require('./config');
+var path = require('path');
 
 function responseTemp(response, head, file) {
   response.writeHead(200, head);
@@ -28,7 +29,11 @@ function start(config) {
       }
     }
 
-    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp)).replace(/\.\./g, '');
+    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp));
+
+    // Sanitize *nowTemp* variable to avoid *Path Traversal* attacks
+  var nowTemp = path.normalize(nowTemp).replace(/^(\.\.(\/|\\|$))+/, '');
+
     var httpHead = header(nowTemp);
     conf.app = conf.getApp(host.backend);
     if(!host) {

--- a/nodeserver.js
+++ b/nodeserver.js
@@ -29,8 +29,8 @@ function start(config) {
     }
 
     // Sanitize *nowTemp* variable to avoid *Path Traversal* attacks
-    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp)).replace(/(\.\.(\/|\\|$))/g, '');
-
+    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp)).replace(/(\.\.)/g, '');
+    
     var httpHead = header(nowTemp);
     conf.app = conf.getApp(host.backend);
     if(!host) {

--- a/nodeserver.js
+++ b/nodeserver.js
@@ -27,8 +27,8 @@ function start(config) {
         host = conf.serv[key];
       }
     }
-    
-    var nowTemp = host.frondend + (request.url.replace('/', '') || host.baseTemp);
+
+    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp)).replace(/\.\./g, '');
     var httpHead = header(nowTemp);
     conf.app = conf.getApp(host.backend);
     if(!host) {

--- a/nodeserver.js
+++ b/nodeserver.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var header = require('./tool/httpHeader').contentType;
 var route = require('./router').response;
 var conf = require('./config');
-var path = require('path');
 
 function responseTemp(response, head, file) {
   response.writeHead(200, head);
@@ -29,10 +28,8 @@ function start(config) {
       }
     }
 
-    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp));
-
     // Sanitize *nowTemp* variable to avoid *Path Traversal* attacks
-    var nowTemp = path.normalize(nowTemp).replace(/^(\.\.(\/|\\|$))+/, '');
+    var nowTemp = (host.frondend + (request.url.replace('/', '') || host.baseTemp)).replace(/(\.\.(\/|\\|$))/g, '');
 
     var httpHead = header(nowTemp);
     conf.app = conf.getApp(host.backend);


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-web-node-server

### ⚙️ Description *

The `nodeserver` server was vulnerable against `path traversal` through the `../` technique, leading to `information exposure` and `file content disclosure`.

### 💻 Technical Description *

I implemented a simple `fix` which makes possible sanitizing any occurrence of `../`and different vectors, using a regex, in order to check and avoid bypasses `OS-based` which are really common nowadays.
I didn't add other `pages` for forbidden message, since when a file is sanitized and `not found`, by design the server will reply with the `index.html` file.

### 🐛 Proof of Concept (PoC) *

1. Download the original server
2. Create the file `test.js` with the following content:

```js
var config = {
    'localhost': {
        backend: __dirname + '/',
        frondend: __dirname + '/',
        baseTemp: 'index.html'
    }
};
var pkg = require('./nodeserver/nodeserver');
pkg.start(config);
```
1. Start the server: `node test.js`
1. PoC: `curl --path-as-is http://localhost:9999/../../../../../../../../../../etc/passwd`
1. Content of `/etc/passwd` is showed :smile:

![Screenshot from 2020-08-22 00-54-28](https://user-images.githubusercontent.com/33063403/90942292-78c76100-e415-11ea-9c26-e97da239ba01.png)

### 🔥 Proof of Fix (PoF) *

Same steps above with fixed version == no `/etc/passwd` showed :smile:

![Screenshot from 2020-08-22 01-10-38](https://user-images.githubusercontent.com/33063403/90942306-85e45000-e415-11ea-8a6e-e8d75f3e8f76.png)

### 👍 User Acceptance Testing (UAT)

All OK :smile: